### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/unicode-props/unicode.scrbl
+++ b/unicode-props/unicode.scrbl
@@ -2,7 +2,7 @@
 
 @(require scribble/manual)
 
-@title{@bold{Unicode Chars}}
+@title{Unicode Chars}
 
 @author[(author+email "John Clements" "clements@racket-lang.org")]
 


### PR DESCRIPTION
For visual consistency with other packages within the docs